### PR TITLE
SLING-7673 - Add null check for transformerConfiguration

### DIFF
--- a/src/main/java/org/apache/sling/rewriter/impl/ProcessorConfigurationImpl.java
+++ b/src/main/java/org/apache/sling/rewriter/impl/ProcessorConfigurationImpl.java
@@ -242,9 +242,11 @@ public class ProcessorConfigurationImpl implements PipelineConfiguration {
             pw.print("        ");
             printConfiguration(pw, this.generatorConfiguration);
             pw.println("    Transformers : ");
-            for(int i=0; i<this.transformerConfigurations.length; i++) {
-                pw.print("        ");
-                printConfiguration(pw, this.transformerConfigurations[i]);
+            if ( this.transformerConfigurations != null ) {
+                for (int i = 0; i < this.transformerConfigurations.length; i++) {
+                    pw.print("        ");
+                    printConfiguration(pw, this.transformerConfigurations[i]);
+                }
             }
             pw.println("    Serializer : ");
             pw.print("        ");


### PR DESCRIPTION
**Jira Ticket:**

https://issues.apache.org/jira/browse/SLING-7673

**Issue:**

transformerConfiguration is coming back as null if no transfromerTypes property values are set.

**Fix:**

Do a null check before checking length
