### PR TITLE
upgrade parent to 52

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>47</version>
+        <version>52</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
to benefit from https://issues.apache.org/jira/browse/SLING-11907
and avoid #10 workaround